### PR TITLE
Initial version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Common IntelliJ Platform excludes
+
+# User specific
+**/.idea
+
+*.suo
+*.user
+.vs/
+[Bb]in/
+[Oo]bj/
+_UpgradeReport_Files/
+[Pp]ackages/
+
+Thumbs.db
+Desktop.ini
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,103 @@
 # JsonObjectValidator
-C# Json validator using anonymous objects
+
+This allows validation of JSON objects by comparing with an anonymous object.
+
+## How to use
+
+### Partial Comparisons
+
+Only the properties in the object that's passed in are compared.
+```csharp
+"{ \"TestedProperty\": \"TestedValue\", \"UntestedProperty\": 5 }"
+    .JsonShouldLookLike(new
+{
+    TestedProperty = "TestedValue"
+});
+```
+
+### Compare arrays
+
+Arrays can be compared too. The individual values will be compared in order.
+```csharp
+// Arrays on their own
+"[ 10, 5, 6 ]".JsonShouldLookLike(new[] { 10, 5, 6 });
+
+// Arrays of objects
+"[ { \"TestProperty\": 1 }, { \"TestProperty\": 2 } ]".JsonShouldLookLike(new[]
+{
+    new
+    {
+        TestProperty = 1
+    },
+    new
+    {
+        TestProperty = 2
+    }
+});
+```
+
+### Custom Comparisons
+
+For values that needs custom matching, an `Expectation` can be created. This is useful in situations when the exact value is not known such as comparing timestamps.
+
+```csharp
+"{ \"TestProperty\": 15, \"ExpectedProperty\": 5 }"
+    .JsonShouldLookLike(new
+{
+    TestProperty = 15,
+    ExpectedProperty = JsonMatcher.Expect<int>(val => val is > 4 and < 15)
+});
+```
+
+For more examples, see the tests.
+
+### Custom Deserialization
+
+`JsonSerializerOptions` can be passed in to verify custom JSON. For an example see the GraphQL response data below.
+```csharp
+// Custom JsonSerializerOptions
+"{ \"testProperty\": 15 }"
+    .JsonShouldLookLike(new
+{
+    TestProperty = 15,
+}, new JsonSerializerOptions
+    {
+        PropertyNameCaseInsensitive = true
+    });
+    
+    
+// Verify JsonNode
+JsonSerializer
+  .Deserialize<JsonNode>("{ \"InnerObject\": { \"TestProperty\": 15 } }")!
+  ["InnerObject"]
+  .JsonShouldLookLike(new
+  {
+      TestProperty = 15,
+  });
+```
+
+
+## Known Limitations
+
+The following scenarios aren't supported at the moment.
+
+- Verifying lists (can use arrays instead)
+- Verifying against concrete classes 
+  - Mostly out of scope here but if the equality comparison operators are implemented it should work
+  - Records and structs should work as well
+  - `IEquatable`, `IComparable` interfaces aren't supported
+- Verifying lists of different types
+  - It should be possible to create an `Expectation` that expects a `JsonNode` or a `JsonElement` and do custom deserialization but it'll be non-trivial
+
+## TODO
+
+- Setup as a nuget package
+- Push to Nuget.org
+- Add releases
+- Setup github CI
+
+## How it works
+
+This was inspired by the wonderful [ExpectedObject](https://github.com/derekgreer/expectedObjects) and [SpecsFor](https://github.com/MattHoneycutt/SpecsFor) projects.
+
+It uses reflection to get the properties of the expected anonymous object and to get individual values of arrays. Then it deserializes the actual object to expected type specified in the expected object and compared against it.

--- a/src/JsonObjectValidator.sln
+++ b/src/JsonObjectValidator.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Validator", "Validator\Validator.csproj", "{6B253C54-8C8D-4C74-B00F-472154B99884}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Validator.Tests", "Validator.Tests\Validator.Tests.csproj", "{A9B17EFA-287C-477F-BFFE-F090378A2C60}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{6B253C54-8C8D-4C74-B00F-472154B99884}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6B253C54-8C8D-4C74-B00F-472154B99884}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6B253C54-8C8D-4C74-B00F-472154B99884}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6B253C54-8C8D-4C74-B00F-472154B99884}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A9B17EFA-287C-477F-BFFE-F090378A2C60}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A9B17EFA-287C-477F-BFFE-F090378A2C60}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A9B17EFA-287C-477F-BFFE-F090378A2C60}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A9B17EFA-287C-477F-BFFE-F090378A2C60}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/src/Validator.Tests/BasicHappyValidationTests.cs
+++ b/src/Validator.Tests/BasicHappyValidationTests.cs
@@ -1,0 +1,185 @@
+namespace Validator.Tests;
+
+public class BasicHappyValidationTests
+{
+    [Test]
+    public void EmptyObject()
+    {
+        "{ \"TestProperty\": \"TestValue\" }"
+            .JsonShouldLookLike(new { });
+    }
+
+    [Test]
+    public void StringProperty()
+    {
+        "{ \"TestProperty\": \"TestValue\" }"
+            .JsonShouldLookLike(new
+        {
+            TestProperty = "TestValue"
+        });
+    }
+
+    [Test]
+    public void IntProperty()
+    {
+        "{ \"TestProperty\": 10 }"
+            .JsonShouldLookLike(new
+        {
+            TestProperty = 10
+        });
+    }
+
+    [Test]
+    public void NullProperty()
+    {
+        "{ \"TestProperty\": null }"
+            .JsonShouldLookLike(new
+        {
+            // This will work but it's nicer to use JsonMatcher.ExpectNull() instead
+            TestProperty = null as string
+        });
+    }
+
+    [Test]
+    public void NewValueTypeProperty()
+    {
+        "{ \"TestProperty\": 2 }"
+            .JsonShouldLookLike(new
+        {
+            TestProperty = new int?(2)
+        });
+    }
+
+    [Test]
+    public void MultipleProperties()
+    {
+        "{ \"FirstProperty\": \"TestValue\", \"SecondProperty\": 2 }"
+            .JsonShouldLookLike(new
+        {
+            FirstProperty = "TestValue",
+            SecondProperty = 2
+        });
+    }
+
+    [Test]
+    public void IntArray()
+    {
+        "[ 10, 5, 6 ]".JsonShouldLookLike(new[] { 10, 5, 6 });
+    }
+
+    [Test]
+    public void ObjectArray()
+    {
+        "[ { \"TestProperty\": 1 }, { \"TestProperty\": 2 } ]".JsonShouldLookLike(new[]
+        {
+            new
+            {
+                TestProperty = 1
+            },
+            new
+            {
+                TestProperty = 2
+            }
+        });
+    }
+
+    [Test]
+    public void IntArrayProperty()
+    {
+        "{ \"TestProperty\": [ 10, 5, 6 ] }"
+            .JsonShouldLookLike(new
+        {
+            TestProperty = new[] { 10, 5, 6 }
+        });
+    }
+
+    [Test]
+    public void NestedObjectWithProperty()
+    {
+        "{ \"TestProperty\": { \"InnerValue\": 5 } }"
+            .JsonShouldLookLike(new
+        {
+            TestProperty = new
+            {
+                InnerValue = 5
+            }
+        });
+    }
+
+    [Test]
+    public void NestedObjectWithArray()
+    {
+        "{ \"TestProperty\": { \"InnerValue\":  [ 5, 4, 3 ] } }"
+            .JsonShouldLookLike(new
+        {
+            TestProperty = new
+            {
+                InnerValue = new[] { 5, 4, 3 }
+            }
+        });
+    }
+
+    [Test]
+    public void MultipleNestedObjects()
+    {
+        "{ \"TestProperty\": { \"SecondaryValue\": { \"TertiaryValue\": 5 } } }"
+            .JsonShouldLookLike(new
+        {
+            TestProperty = new
+            {
+                SecondaryValue = new
+                {
+                    TertiaryValue = 5
+                }
+            }
+        });
+    }
+
+    [Test]
+    public void NestedObjectArray()
+    {
+        "{ \"TestProperty\": [ { \"SecondaryValue\": 3 }, { \"SecondaryValue\": 5 } ] }"
+            .JsonShouldLookLike(new
+        {
+            TestProperty = new[]
+            {
+                new
+                {
+                    SecondaryValue = 3
+                },
+                new
+                {
+                    SecondaryValue = 5
+                }
+            }
+        });
+    }
+
+    [Test]
+    public void NestedArrayOfArrays()
+    {
+        "{ \"TestProperty\": [ { \"SecondaryValue\": [ 3, 5, 6 ] } ] }"
+            .JsonShouldLookLike(new
+        {
+            TestProperty = new[]
+            {
+                new
+                {
+                    SecondaryValue = new[] { 3, 5, 6 }
+                }
+            }
+        });
+    }
+
+    [Test]
+    public void PartialComparison()
+    {
+        // Verify only a part of the JSON
+
+        "{ \"TestedProperty\": \"TestedValue\", \"UntestedProperty\": 5 }"
+            .JsonShouldLookLike(new
+        {
+            TestedProperty = "TestedValue"
+        });
+    }
+}

--- a/src/Validator.Tests/BasicSadValidationTests.cs
+++ b/src/Validator.Tests/BasicSadValidationTests.cs
@@ -1,0 +1,246 @@
+using System.Text.Json;
+
+namespace Validator.Tests;
+
+public class BasicSadValidationTests
+{
+    [Test]
+    public void StringProperty()
+    {
+        var exception = Assert.Throws<JsonValidationException>(() =>
+        {
+            "{ \"TestProperty\": \"TestValue\" }"
+                .JsonShouldLookLike(new
+                {
+                    TestProperty = "NotTestValue"
+                });
+        });
+
+        Assert.That(exception!.Path, Is.EqualTo("ExpectedObject.TestProperty"));
+    }
+
+    [Test]
+    public void IntProperty()
+    {
+        Assert.Throws<JsonValidationException>(() =>
+        {
+            "{ \"TestProperty\": 10 }"
+                .JsonShouldLookLike(new
+            {
+                TestProperty = 11
+            });
+        });
+    }
+
+    [Test]
+    public void NullJsonValue()
+    {
+        Assert.Throws<JsonValidationException>(() =>
+        {
+            "{ \"TestProperty\": null }"
+                .JsonShouldLookLike(new
+            {
+                TestProperty = new int?(2)
+            });
+        });
+    }
+
+    [Test]
+    public void NullExpectedValue()
+    {
+        Assert.Throws<JsonValidationException>(() =>
+        {
+            "{ \"TestProperty\": 10 }"
+                .JsonShouldLookLike(new
+            {
+                TestProperty = null as int?
+            });
+        });
+    }
+
+    [Test]
+    public void OneOfMultipleProperties()
+    {
+        var exception = Assert.Throws<JsonValidationException>(() =>
+        {
+            "{ \"FirstProperty\": \"TestValue\", \"SecondProperty\": 2 }"
+                .JsonShouldLookLike(new
+            {
+                FirstProperty = "TestValue",
+                SecondProperty = 3
+            });
+        });
+
+        Assert.That(exception!.Path, Is.EqualTo("ExpectedObject.SecondProperty"));
+    }
+
+    [Test]
+    public void IntArray()
+    {
+        Assert.Throws<JsonValidationException>(() =>
+        {
+            "[ 10, 5, 6 ]".JsonShouldLookLike(new[] { 10, 5, 7 });
+        });
+    }
+
+    [Test]
+    public void ObjectArray()
+    {
+        Assert.Throws<JsonValidationException>(() =>
+        {
+            "[ { \"TestProperty\": 1 }, { \"TestProperty\": 2 } ]".JsonShouldLookLike(new[]
+            {
+                new
+                {
+                    TestProperty = 1
+                },
+                new
+                {
+                    TestProperty = 3
+                }
+            });
+        });
+    }
+
+    [Test]
+    public void ExpectLess()
+    {
+        Assert.Throws<JsonValidationException>(() =>
+        {
+            "[ 10, 5, 6 ]".JsonShouldLookLike(new[] { 10, 5 });
+        });
+    }
+
+    [Test]
+    public void ExpectMore()
+    {
+        Assert.Throws<JsonValidationException>(() =>
+        {
+            "[ 10, 5, 6 ]".JsonShouldLookLike(new[] { 10, 5, 6, 1 });
+        });
+    }
+
+    [Test]
+    public void InvalidArrayItem()
+    {
+        Assert.Throws<JsonValidationException>(() =>
+        {
+            "{ \"TestProperty\": [ 10, 5, 6 ] }"
+                .JsonShouldLookLike(new
+            {
+                TestProperty = new[] { 10, 5, 7 }
+            });
+        });
+    }
+
+    [Test]
+    public void NestedObjectWithProperty()
+    {
+        Assert.Throws<JsonValidationException>(() =>
+        {
+            "{ \"TestProperty\": { \"InnerValue\": 5 } }"
+                .JsonShouldLookLike(new
+            {
+                TestProperty = new
+                {
+                    InnerValue = 6
+                }
+            });
+        });
+    }
+
+    [Test]
+    public void NestedObjectWithArray()
+    {
+        Assert.Throws<JsonValidationException>(() =>
+        {
+            "{ \"TestProperty\": { \"InnerValue\":  [5, 4, 3] } }"
+                .JsonShouldLookLike(new
+            {
+                TestProperty = new
+                {
+                    InnerValue = new[] { 5, 4, 2 }
+                }
+            });
+        });
+    }
+
+    [Test]
+    public void MultipleNestedObjects()
+    {
+        Assert.Throws<JsonValidationException>(() =>
+        {
+            "{ \"TestProperty\": { \"SecondaryValue\": { \"TertiaryValue\": 5 } } }"
+                .JsonShouldLookLike(new
+            {
+                TestProperty = new
+                {
+                    SecondaryValue = new
+                    {
+                        TertiaryValue = 3
+                    }
+                }
+            });
+        });
+    }
+
+    [Test]
+    public void NestedObjectArray()
+    {
+        Assert.Throws<JsonValidationException>(() =>
+        {
+            "{ \"TestProperty\": [ { \"SecondaryValue\": 3 }, { \"SecondaryValue\": 5 } ] }"
+                .JsonShouldLookLike(new
+            {
+                TestProperty = new[]
+                {
+                    new
+                    {
+                        SecondaryValue = 3
+                    },
+                    new
+                    {
+                        SecondaryValue = 4
+                    }
+                }
+            });
+        });
+    }
+
+    [Test]
+    public void NestedArrayOfArrays()
+    {
+        var exception = Assert.Throws<JsonValidationException>(() =>
+        {
+            "{ \"TestProperty\": [ { \"SecondaryValue\": [ 3, 5, 6 ] } ] }"
+                .JsonShouldLookLike(new
+            {
+                TestProperty = new[]
+                {
+                    new
+                    {
+                        SecondaryValue = new[] { 3, 5, 7 }
+                    }
+                }
+            });
+        });
+
+        Assert.That(exception!.Path, Is.EqualTo("ExpectedObject.TestProperty[0].SecondaryValue[2]"));
+    }
+
+    [Test]
+    public void ExpectInvalidType()
+    {
+        var exception = Assert.Throws<JsonValidationException>(() =>
+        {
+            "{ \"TestProperty\": 5 }"
+                .JsonShouldLookLike(new
+            {
+                TestProperty = "Five"
+            });
+        });
+
+        Assert.That(exception!.Path, Is.EqualTo("ExpectedObject.TestProperty"));
+        Assert.IsInstanceOf<JsonException>(exception.InnerException);
+    }
+}

--- a/src/Validator.Tests/ConcreteObjectValidationTests.cs
+++ b/src/Validator.Tests/ConcreteObjectValidationTests.cs
@@ -1,0 +1,56 @@
+﻿namespace Validator.Tests;
+
+public class ConcreteTypeValidationTests
+{
+    [Test]
+    public void NestedObjectWithProperty()
+    {
+        // Technically, we do support concrete classes as long as
+        // they support equality comparisons
+
+        "{ \"TestProperty\": { \"InnerInt\": 5 } }"
+            .JsonShouldLookLike(new
+        {
+            TestProperty = new TestObject
+            {
+                InnerInt = 5
+            }
+        });
+    }
+
+    [Test]
+    public void NestedObjectAsExpectation()
+    {
+        "{ \"TestProperty\": { \"InnerInt\": 5 } }"
+            .JsonShouldLookLike(new
+        {
+            TestProperty = JsonMatcher.ExpectValue(new TestObject
+            {
+                InnerInt = 5
+            })
+        });
+    }
+
+    private class TestObject
+    {
+        public int InnerInt { get; init; }
+
+        private bool Equals(TestObject other)
+        {
+            return InnerInt == other.InnerInt;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((TestObject) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return InnerInt;
+        }
+    }
+}

--- a/src/Validator.Tests/ExpectationHappyTests.cs
+++ b/src/Validator.Tests/ExpectationHappyTests.cs
@@ -1,0 +1,62 @@
+namespace Validator.Tests;
+
+public class ExpectationHappyTests
+{
+    [Test]
+    public void ExpectNull()
+    {
+        "{ \"TestProperty\": null }"
+            .JsonShouldLookLike(new
+        {
+            TestProperty = JsonMatcher.ExpectNull()
+        });
+    }
+
+    [Test]
+    public void ExpectAnyInt()
+    {
+        "{ \"TestProperty\": 5 }"
+            .JsonShouldLookLike(new
+        {
+            TestProperty = JsonMatcher.ExpectAny<int>()
+        });
+    }
+
+    [Test]
+    public void ExpectNullableValues()
+    {
+        "[ { \"TestProperty\": null }, { \"TestProperty\": 5 } ]"
+            .JsonShouldLookLike(new[]
+        {
+            new
+            {
+                TestProperty = JsonMatcher.Expect<int?>(val => val is null)
+            },
+            new
+            {
+                TestProperty = JsonMatcher.ExpectValue<int?>(5)
+            }
+        });
+    }
+
+    [Test]
+    public void ExpectInt()
+    {
+        "{ \"TestProperty\": 5 }"
+            .JsonShouldLookLike(new
+        {
+            TestProperty = JsonMatcher.Expect<int>(val => val == 5)
+        });
+    }
+
+    [Test]
+    public void ExpectPartialValidation()
+    {
+        "{ \"TestProperty\": 15, \"ExpectedProperty\": 5 }"
+            .JsonShouldLookLike(new
+        {
+            TestProperty = 15,
+            ExpectedProperty = JsonMatcher.Expect<int>(val => val is > 4 and < 15)
+        });
+    }
+}

--- a/src/Validator.Tests/ExpectationSadTests.cs
+++ b/src/Validator.Tests/ExpectationSadTests.cs
@@ -1,0 +1,69 @@
+using System.Text.Json;
+
+namespace Validator.Tests;
+
+public class ExpectationSadTests
+{
+    [Test]
+    public void ExpectNull()
+    {
+        Assert.Throws<JsonValidationException>(() =>
+        {
+            "{ \"TestProperty\": 1 }"
+                .JsonShouldLookLike(new
+            {
+                TestProperty = JsonMatcher.ExpectNull()
+            });
+        });
+    }
+
+    [Test]
+    public void ExpectInvalidType()
+    {
+        var exception = Assert.Throws<JsonValidationException>(() =>
+        {
+            "{ \"TestProperty\": 5 }"
+                .JsonShouldLookLike(new
+            {
+                TestProperty = JsonMatcher.ExpectAny<string>()
+            });
+        });
+
+        Assert.IsInstanceOf<JsonException>(exception!.InnerException);
+    }
+
+    [Test]
+    public void ExpectInt()
+    {
+        Assert.Throws<JsonValidationException>(() =>
+        {
+            "{ \"TestProperty\": 5 }"
+                .JsonShouldLookLike(new
+            {
+                TestProperty = JsonMatcher.Expect<int>(val => val == 6)
+            });
+        });
+    }
+
+    [Test]
+    public void ExpectNullableValues()
+    {
+        var exception = Assert.Throws<JsonValidationException>(() =>
+        {
+            "[ { \"TestProperty\": null }, { \"TestProperty\": 5 } ]"
+                .JsonShouldLookLike(new[]
+            {
+                new
+                {
+                    TestProperty = JsonMatcher.Expect<int?>(val => val is not null)
+                },
+                new
+                {
+                    TestProperty = JsonMatcher.Expect<int?>(val => val == 5)
+                }
+            });
+        });
+
+        Assert.That(exception!.Path, Is.EqualTo("ExpectedObject[0].TestProperty"));
+    }
+}

--- a/src/Validator.Tests/JsonSerializerOptionsTests.cs
+++ b/src/Validator.Tests/JsonSerializerOptionsTests.cs
@@ -1,0 +1,32 @@
+﻿using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Validator.Tests;
+
+public class JsonSerializerOptionsTests
+{
+    [Test]
+    public void CustomSerializationOptions()
+    {
+        "{ \"testProperty\": 15 }"
+            .JsonShouldLookLike(new
+        {
+            TestProperty = 15,
+        }, new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            });
+    }
+
+    [Test]
+    public void VerifyJsonNode()
+    {
+        JsonSerializer
+            .Deserialize<JsonNode>("{ \"InnerObject\": { \"TestProperty\": 15 } }")!
+            ["InnerObject"]
+            .JsonShouldLookLike(new
+            {
+                TestProperty = 15,
+            });
+    }
+}

--- a/src/Validator.Tests/Usings.cs
+++ b/src/Validator.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using NUnit.Framework;

--- a/src/Validator.Tests/Validator.Tests.csproj
+++ b/src/Validator.Tests/Validator.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+        <PackageReference Include="NUnit" Version="3.13.3" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+        <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
+        <PackageReference Include="coverlet.collector" Version="3.1.2" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Validator\Validator.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Validator/AssemblySettings.cs
+++ b/src/Validator/AssemblySettings.cs
@@ -1,0 +1,1 @@
+﻿[assembly: CLSCompliant(true)]

--- a/src/Validator/Expectation.cs
+++ b/src/Validator/Expectation.cs
@@ -1,0 +1,24 @@
+﻿using System.Diagnostics;
+
+namespace Validator;
+
+[StackTraceHidden]
+public class Expectation<T>
+{
+    private readonly Func<T, bool> _expectation;
+
+    /// <summary>
+    /// Json value expectation
+    /// </summary>
+    /// <param name="expectation">A function that evaluates the value and returns a boolean</param>
+    /// <typeparam name="T">Type of the field</typeparam>
+    public Expectation(Func<T, bool> expectation)
+    {
+        _expectation = expectation;
+    }
+
+    /// <summary>
+    /// For internal use only. Used to validate the expectation.
+    /// </summary>
+    internal bool Verify(T input) => _expectation(input);
+}

--- a/src/Validator/JsonMatcher.cs
+++ b/src/Validator/JsonMatcher.cs
@@ -1,0 +1,31 @@
+﻿using System.Text.Json;
+
+namespace Validator;
+
+public static class JsonMatcher
+{
+    /// <summary>
+    /// Execute a custom comparison
+    /// </summary>
+    /// <param name="expectation">A function that evaluates the value and returns a boolean</param>
+    /// <typeparam name="T">Type of the field</typeparam>
+    public static Expectation<T> Expect<T>(Func<T, bool> expectation) => new(expectation);
+
+    /// <summary>
+    /// Match with a known value. To be used on arrays with matched values.
+    /// </summary>
+    /// <param name="expectedValue">The expected value</param>
+    /// <typeparam name="T">Type of the field</typeparam>
+    public static Expectation<T> ExpectValue<T>(T expectedValue) => new(value => Equals(value, expectedValue));
+
+    /// <summary>
+    /// Verify a field of type exists
+    /// </summary>
+    /// <typeparam name="T">Type of the field</typeparam>
+    public static Expectation<T> ExpectAny<T>() => new(_ => true);
+
+    /// <summary>
+    /// Verify the field exists and it is null
+    /// </summary>
+    public static Expectation<JsonElement> ExpectNull() => new(e => e.ValueKind == JsonValueKind.Null);
+}

--- a/src/Validator/JsonValidationException.cs
+++ b/src/Validator/JsonValidationException.cs
@@ -1,0 +1,24 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace Validator;
+
+[SuppressMessage("Design", "CA1032:Implement standard exception constructors")]
+public class JsonValidationException : Exception
+{
+    /// <summary>
+    /// The location of the property or item that failed validation
+    /// </summary>
+    public string Path { get; }
+
+    internal JsonValidationException(string message, string path)
+        : base($"{message} at {path}")
+    {
+        Path = path;
+    }
+
+    internal JsonValidationException(string message, string path, Exception innerException)
+        : base($"{message} at {path}", innerException)
+    {
+        Path = path;
+    }
+}

--- a/src/Validator/JsonValidator.cs
+++ b/src/Validator/JsonValidator.cs
@@ -1,0 +1,145 @@
+﻿using System.Diagnostics;
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Validator;
+
+[StackTraceHidden]
+public static class JsonValidator
+{
+    /// <summary>
+    /// Compare a json object to an anonymous object
+    /// </summary>
+    /// <param name="json">Json string to validate</param>
+    /// <param name="expectedObject">expression that returns an anonymous object to compare the JSON to</param>
+    /// <param name="jsonSerializerOptions">[Optional] Options to control the behavior during parsing the JSON</param>
+    /// <exception cref="JsonValidationException">Validation failure</exception>
+    public static void JsonShouldLookLike<T>(this string json,
+        T expectedObject,
+        JsonSerializerOptions? jsonSerializerOptions = default) where T : class
+    {
+        JsonNode? actualObject = JsonSerializer.Deserialize<JsonNode>(json, jsonSerializerOptions);
+        TraverseValue(expectedObject, actualObject, "ExpectedObject");
+    }
+
+    /// <summary>
+    /// Compare a json object to an anonymous object
+    /// </summary>
+    /// <param name="jsonNode">JsonNode to validate</param>
+    /// <param name="expectedObject">expression that returns an anonymous object to compare the JSON to</param>
+    /// <exception cref="JsonValidationException">Validation failure</exception>
+    public static void JsonShouldLookLike<T>(this JsonNode? jsonNode, T expectedObject) where T : class
+    {
+        TraverseValue(expectedObject, jsonNode, "ExpectedObject");
+    }
+
+    private static void TraverseValue(object? expectedObject, JsonNode? actualObject, string path)
+    {
+        if (expectedObject is null && actualObject is null)
+            return;
+
+        if (expectedObject is null)
+            throw new JsonValidationException($"Expected null but actual is {actualObject?.ToJsonString()}", path);
+
+        Type expectedObjectType = expectedObject.GetType();
+
+        // Handle expectations
+        if (expectedObjectType.IsExpectation())
+        {
+            RunExpectation(expectedObject, actualObject, path);
+            return;
+        }
+
+        // We know the expected object is not null at this point so if the actualObject is null, they aren't equal.
+        if (actualObject is null)
+            throw new JsonValidationException("Expected a value but the actual is null", path);
+
+        // Handle new anonymous object initializers
+        if (expectedObjectType.IsClass
+            && expectedObjectType.IsAnonymousObject())
+        {
+            TraverseObject(expectedObject, actualObject, path);
+            return;
+        }
+
+        // Handle new array initializers
+        if (expectedObjectType.IsArray)
+        {
+            Array? expectedArray = expectedObject as Array;
+            JsonArray actualArray = actualObject.AsArray();
+
+            if (expectedArray is null || actualArray is null)
+                throw new InvalidOperationException();
+
+            TraverseArray(expectedArray, actualArray, path);
+            return;
+        }
+
+        // Check if the two objects/values are equal
+        if (expectedObject.Equals(Deserialize(actualObject, expectedObjectType, path)))
+        {
+            return;
+        }
+
+        // Throw if the values don't match or if it's an unhandled expression type
+        throw new JsonValidationException("Values don't match", path);
+    }
+
+    private static void TraverseObject(object expectedObject, JsonNode actualObject, string position)
+    {
+        Type expectedObjectType = expectedObject.GetType();
+        var properties = expectedObjectType.GetProperties();
+
+        // Iterate through the properties of the initializer of an anonymous object
+        foreach (var property in properties)
+        {
+            object? expectedValue = property.GetValue(expectedObject);
+            JsonNode? actualValue = actualObject[property.Name];
+
+            TraverseValue(expectedValue, actualValue, string.Join('.', position, property.Name));
+        }
+    }
+
+    private static void TraverseArray(Array expectedArray, JsonArray actualArray, string path)
+    {
+        if(expectedArray.Length != actualArray.Count)
+            throw new JsonValidationException("Lists have different lengths", path);
+
+        // Iterate through the initializer expressions inside initializer of the array
+        for (int i = 0; i < expectedArray.Length; i++)
+        {
+            object? expected = expectedArray.GetValue(i);
+            JsonNode? actual = actualArray[i];
+
+            TraverseValue(expected, actual, $"{path}[{i}]");
+        }
+    }
+
+    private static void RunExpectation(object expectedObject, JsonNode? actual, string path)
+    {
+        Type expectedObjectType = expectedObject.GetType();
+        Type internalType = expectedObjectType.GenericTypeArguments[0];
+        var actualValue = Deserialize(actual, internalType, path);
+
+        MethodInfo verifyMethod = expectedObjectType.GetMethod(nameof(Expectation<string>.Verify),
+            BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+        bool successful = (bool) verifyMethod.Invoke(expectedObject, new[] { actualValue })!;
+
+        if (!successful)
+            throw new JsonValidationException("Expectation failed", path);
+    }
+
+    private static object? Deserialize(JsonNode? jsonNode, Type type, string path)
+    {
+        try
+        {
+            return jsonNode.Deserialize(type);
+        }
+        catch (JsonException e)
+        {
+            throw new JsonValidationException($"Couldn't deserialize into {type.Name}", path, e);
+        }
+    }
+}

--- a/src/Validator/TypeExtensions.cs
+++ b/src/Validator/TypeExtensions.cs
@@ -1,0 +1,11 @@
+﻿namespace Validator;
+
+internal static class TypeExtensions
+{
+    public static bool IsAnonymousObject(this Type type) =>
+        type.IsClass && type.IsSealed && !type.IsPublic &&
+        type.Name.Contains("AnonymousType", StringComparison.InvariantCulture);
+
+    public static bool IsExpectation(this Type type) =>
+        type.IsClass && type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Expectation<>);
+}

--- a/src/Validator/Validator.csproj
+++ b/src/Validator/Validator.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <AnalysisMode>All</AnalysisMode>
+    </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
This allows validation of JSON objects by comparing with an anonymous object.

## How to use

### Partial Comparisons

Only the properties in the object that's passed in are compared.
```csharp
"{ \"TestedProperty\": \"TestedValue\", \"UntestedProperty\": 5 }"
    .JsonShouldLookLike(new
{
    TestedProperty = "TestedValue"
});
```

### Compare arrays

Arrays can be compared too. The individual values will be compared in order.
```csharp
// Arrays on their own
"[ 10, 5, 6 ]".JsonShouldLookLike(new[] { 10, 5, 6 });
// Arrays of objects
"[ { \"TestProperty\": 1 }, { \"TestProperty\": 2 } ]".JsonShouldLookLike(new[]
{
    new
    {
        TestProperty = 1
    },
    new
    {
        TestProperty = 2
    }
});
```

### Custom Comparisons

For values that needs custom matching, an `Expectation` can be created. This is useful in situations when the exact value is not known such as comparing timestamps.

```csharp
"{ \"TestProperty\": 15, \"ExpectedProperty\": 5 }"
    .JsonShouldLookLike(new
{
    TestProperty = 15,
    ExpectedProperty = JsonMatcher.Expect<int>(val => val is > 4 and < 15)
});
```

For more examples, see the tests.

### Custom Deserialization

`JsonSerializerOptions` can be passed in to verify custom JSON. For an example see the GraphQL response data below.
```csharp
// Custom JsonSerializerOptions
"{ \"testProperty\": 15 }"
    .JsonShouldLookLike(new
{
    TestProperty = 15,
}, new JsonSerializerOptions
    {
        PropertyNameCaseInsensitive = true
    });
    
    
// Verify JsonNode
JsonSerializer
  .Deserialize<JsonNode>("{ \"InnerObject\": { \"TestProperty\": 15 } }")!
  ["InnerObject"]
  .JsonShouldLookLike(new
  {
      TestProperty = 15,
  });
```


## Known Limitations

The following scenarios aren't supported at the moment.

- Verifying lists (can use arrays instead)
- Verifying against concrete classes 
  - Mostly out of scope here but if the equality comparison operators are implemented it should work
  - Records and structs should work as well
  - `IEquatable`, `IComparable` interfaces aren't supported
- Verifying lists of different types
  - It should be possible to create an `Expectation` that expects a `JsonNode` or a `JsonElement` and do custom deserialization but it'll be non-trivial

## TODO

- Setup as a nuget package
- Push to Nuget.org
- Add releases
- Setup github CI

## How it works

This was inspired by the wonderful [ExpectedObject](https://github.com/derekgreer/expectedObjects) and [SpecsFor](https://github.com/MattHoneycutt/SpecsFor) projects.

It uses reflection to get the properties of the expected anonymous object and to get individual values of arrays. Then it deserializes the actual object to expected type specified in the expected object and compared against it.